### PR TITLE
ISSUE-1 fix: use current latest available 'docker-ce'

### DIFF
--- a/build-environment/jenkins/Dockerfile
+++ b/build-environment/jenkins/Dockerfile
@@ -20,7 +20,7 @@ RUN add-apt-repository \
    $(lsb_release -cs) \
    stable"
 RUN apt-get update  -qq \
-    && apt-get install docker-ce=17.12.1~ce-0~debian -y
+    && apt-get install docker-ce -y
 RUN usermod -aG docker jenkins
 
 # preconfigure jobs


### PR DESCRIPTION
- basic use-case of this demo still works: jenkinsRuns,
and builds e.g. 01-packaing jobs on demand.

Adresses #1 